### PR TITLE
Handle complex file names in rose_listen

### DIFF
--- a/rose_listen.py
+++ b/rose_listen.py
@@ -82,15 +82,32 @@ if __name__ == '__main__':
             print("You aren't playing any episode currently.")
         else:
             filename = unquote(file_location[file_location.rfind('/') + 1:file_location.rfind('.')])
-            show = filename[0:filename.rfind(' ')]
-            epi = filename[filename.rfind(' ') + 1:]
+
             try:
+                s = '[Ss][0-9]+[Ee][0-9]+'
+                end = [m.start() for m in re.finditer(s, filename)]
+                each = end[0]
+                name = filename[0:each]
+                epi = filename[each:each + 6]
+                epi = epi.upper()
+
                 s_index = epi.index('S')
                 e_index = epi.index('E')
                 season_num = int(epi[s_index + 1:e_index])
                 episode_num = int(epi[e_index + 1:])
+
+                show = ''
+                for i in range(len(name)):
+                    if name[i] == '.':
+                        show += ' '
+                    else:
+                        show += name[i]
+                while show[len(show) - 1] == '-' or show[len(show) - 1] == ' ':
+                    show = show[:-1]
+
                 episode_scrape(show, season_num, episode_num)
-            except ValueError:
+            except (ValueError, IndexError) as e:
                 print('Invalid episode nomenclature')
+
     except FileNotFoundError:
         print('Please install playerctl to continue using this feature.')


### PR DESCRIPTION
Solves #23 
### Changes
rose_listen.py can now handle complex file names
### Screenshots
When playing `Doctor.Who.S05e12.extraneoustext.mkv`
![screenshot from 2018-12-23 14-05-47](https://user-images.githubusercontent.com/38394281/50382265-8cab4480-06c1-11e9-9dd1-ee2d5b20e5bb.png)

When playing `Attack On Titan - S03E01 - Smoke Signal (720p) (x265) (E-Subs) [Baba_Bhayanak].mkv`
![screenshot from 2018-12-23 14-48-42](https://user-images.githubusercontent.com/38394281/50382283-ee6bae80-06c1-11e9-938a-454891ba1594.png)

When playing `Bojack Horseman - S01E01 [WEBRip 720p] [Daiki_Aomine].mkv`
![screenshot from 2018-12-23 14-11-42](https://user-images.githubusercontent.com/38394281/50382285-f4618f80-06c1-11e9-91bf-3a60ab91edf3.png)

When playing `Brooklyn.Nine-Nine.S01E01.1080p.WEB-DL.DD5.1.H.264-NTb.mkv`
![screenshot from 2018-12-23 14-10-05](https://user-images.githubusercontent.com/38394281/50382284-f1669f00-06c1-11e9-9dd3-9a9ef815fe16.png)

